### PR TITLE
Add Pepecoin network

### DIFF
--- a/lib/Bitcoin/Crypto/Network.pm
+++ b/lib/Bitcoin/Crypto/Network.pm
@@ -277,6 +277,36 @@ __PACKAGE__->register(
 	bip44_coin => 1,
 );
 
+### PEPECOIN
+# unfortunately Pepecoin mainnet shares a WIF byte with Dogecoin mainnet
+
+__PACKAGE__->register(
+	id => 'pepecoin',
+	name => 'Pepecoin Mainnet',
+	p2pkh_byte => "\x38",
+	p2sh_byte => "\x16",
+	wif_byte => "\x9e",
+
+	extprv_version => 0x02fac398,
+	extpub_version => 0x02facafd,
+
+	bip44_coin => 3434,
+);
+
+# almost all the same as Dogecoin Testnet
+__PACKAGE__->register(
+	id => 'pepecoin_testnet',
+	name => 'Pepecoin Testnet',
+	p2pkh_byte => "\x71",
+	p2sh_byte => "\xc4",
+	wif_byte => "\xf1",
+
+	extprv_version => 0x04358394,
+	extpub_version => 0x043587cf,
+
+	bip44_coin => 1,
+);
+
 1;
 
 __END__
@@ -362,6 +392,14 @@ defined with id: C<dogecoin>
 =head2 Dogecoin Testnet
 
 defined with id: C<dogecoin_testnet>
+
+=head2 Pepecoin Mainnet
+
+defined with id: C<pepecoin>
+
+=head2 Pepecoin Testnet
+
+defined with id: C<pepecoin_testnet>
 
 =head1 CONFIGURATION
 

--- a/t/predefined-networks.t
+++ b/t/predefined-networks.t
@@ -53,6 +53,26 @@ my @predefined_networks = (
 		wif => 'cjtn5eFTBAPzwZehT3VaSqdTdXFUctkdzroaWo7SScapaYA6iysa',
 		address => 'nio8BJ7epGHSteXUisJyCxgbxDQDX41Zw5',
 	},
+
+	{
+		id => 'pepecoin',
+		account_prv =>
+			'dgpv57XkTszWUiM7L8xUAvXaj7evMpYFKcdYCQihFKwM1vyvEyGBSEJ8NuPU8aSgoNkfzPJ92KvUyrwAvJPfDzE17cF1FkSaVEhmkXkqrg7qwN6',
+		account_pub =>
+			'dgub8rQmoZvQ2s1SczcdDA9YqyCWpNut9jfFV1VuQSLKp42vo2Nsqzqu2Co7ho4pGi9QFs49a6595R5zmfdmgDR95TK6msW2oQi7KSCaqURZYwi',
+		wif => 'QVvidFn85YHvjxzJj1M4y1tyF1k71jyabE7zBT6rcwgk3mqzUvQ4',
+		address => 'PbMTSd5ko3YtgF8Y4F95VoYEM5tNaYeWQk',
+	},
+
+	{
+		id => 'pepecoin_testnet',
+		account_prv =>
+			'tprv8fTqCYXFU7MCArvB8n529P5qBqb4kBjkB3DtfN86WazW6wxhmnAHqcbm3FuLeuTmdTqXm6MqfxeyzCyh4BRUNbsFc6CzzibrfvfUu3EKddZ',
+		account_pub =>
+			'tpubDC9sLxZVcV2s4Kwy2RjcYnjwks6zuWvekLpfwtAPvrntwSDUQAyt27DdDRHwDL63NxX7RuXD7Bgw7Qaf4vvssYdcVuv5MfvkFjZiDiRsfC7',
+		wif => 'cn445egncJLLcv64dJ7C3TkPu5RFJUUv6tpod9riNfEpRFS6TDoq',
+		address => 'nXcqZp5BGKxqHx5UTA8F8x45Dqa93Jb3kK',
+	},
 );
 
 my %default_mapped = map { $_ => 1 } Bitcoin::Crypto::Network->find;
@@ -62,6 +82,9 @@ for my $case (@predefined_networks) {
 		ok defined $default_mapped{$case->{id}}, 'network available ok';
 
 		$master_key->set_network($case->{id});
+
+		# Dogecoin and Pepecoin share the same WIF bit, so we need to set the default network explicitly
+		Bitcoin::Crypto::Network->get($case->{id})->set_default;
 
 		if ($case->{account_prv}) {
 			my $derived = $master_key->derive_key_bip44(get_account => 1);


### PR DESCRIPTION
Test cases validated by importing the wif generated from the mnemonic into Pepecoin core and checking the generated address against the address generated by this code. By extension (no pun intended), the private and public keys must also be derived accurately.

Note that Pepecoin, as a fork of Dogecoin, uses the same byte value for its WIF prefix. This is unfortunate in some ways, but it also makes a good test of other features in this distribution.

[Pepecoin mainnet chainparams](https://github.com/pepecoinppc/pepecoin/blob/master/src/chainparams.cpp#L166-L170).

[Pepecoin testnet chainparams](https://github.com/pepecoinppc/pepecoin/blob/master/src/chainparams.cpp#L296-L300).

[Pepecoin SLIP44 PR](https://github.com/satoshilabs/slips/pull/1749).